### PR TITLE
Remove unneeded wrapper object and add toNamed

### DIFF
--- a/index.js
+++ b/index.js
@@ -112,11 +112,19 @@ function warnAboutConfigs(dir) {
 
 function warningsForConfig(env, dir) {
 
-    return loadEnvConfig(env, dir).then(function (obj) {
-        var middleware = obj.middleware;
-        var config = obj.config;
+    return loadEnvConfig(env, dir).then(function (config) {
+        var middleware = toNamed(config.conf.get('middleware'));
         return warningsAboutUnspecifiedEnables(middleware).concat(listDeprecatedMiddleware(middleware)).map(function (e) {
             return util.format("In environment '%s', %s", config.env, e);
         });
     });
+}
+
+function toNamed(obj) {
+    var out = [];
+    for (var k in obj) {
+        out.push({name: k, value: obj[k]});
+    }
+
+    return out;
 }

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "bluebird": "^2.9.30",
     "express": "^4.13.0",
     "glob": "^5.0.10",
-    "kraken-config-enumerator": "^1.0.0",
+    "kraken-config-enumerator": "^2.0.1",
     "kraken-js": "^2.0.0-rc.1",
     "semver": "^4.3.6",
     "strip-json-comments": "^1.0.2",


### PR DESCRIPTION
- Removed the wrapping object of config and middleware
- Moved toNamed function to kraken-upgrader from
  kraken-config-enumerator
